### PR TITLE
Fix order of events, sort by start date

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -19,11 +19,10 @@ class EventsController < ApplicationController
 
   def index
     # see https://www.justinweiss.com/articles/search-and-filter-rails-models-without-bloating-your-controller/
-    @events = Event.upcoming.where(nil) # creates an anonymous scope
+    @events = Event.upcoming.where(nil).order(:start_date) # creates an anonymous scope
     @events = @events.filter_by_city(filter_params[:city]) if params[:city].present?
     @events = @events.filter_by_country(filter_params[:country]) if params[:country].present?
     @events = @events.filter_by_dance_types(filter_params[:dance_type]) if params[:dance_type].present?
-    @events.order('start_date')
   end
 
   private

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,7 +2,7 @@
 html
   head
     title
-      | Swinge Dance Events
+      | Swinge Dance Festivals
     meta name="viewport" content="width=device-width,initial-scale=1"
     = csrf_meta_tags
     = csp_meta_tag

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe 'Events', type: :request do
       expect(response.body).to include @events.second.start_date.strftime('%B %d, %Y')
     end
 
+    it 'sorts the events by start date' do
+      create(:event, title: 'March', start_date: '01.03.2099'.to_date, end_date: '03.03.2099'.to_date)
+      create(:event, title: 'January', start_date: '01.01.2099'.to_date, end_date: '03.01.2099'.to_date)
+      get '/events'
+
+      document = Nokogiri::HTML(response.body) # TODO: This feels like a hack
+      table = document.search('table')
+      # table.text is e.g. "MarchHamburgMarch 01, 2099JanuaryHamburgJanuary 01, 2099"
+      expect(table.text).to start_with 'January'
+    end
+
     context 'filters' do
       let!(:event_shag_hamburg) { create(:event, title: 'foo foo', city: 'Hamburg', dance_types: ['sankt_luis_shag']) }
       let!(:event_shag_berlin) { create(:event, title: 'bar bar', city: 'Berlin', dance_types: ['sankt_luis_shag']) }


### PR DESCRIPTION
Bug: Events appeared in random order, but are supposed to be ordered by start_date. Fixed and added regression spec.