### PR TITLE
github actions - use ruby/setup-ruby@v1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Ruby and gems
-        uses: ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
+        uses: ruby/setup-ruby@v1 # ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
         with:
           bundler-cache: true
       - name: Generate binstubs

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Ruby and gems
-        uses: ruby/setup-ruby@v1 # ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - name: Generate binstubs

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1 # ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
         with:
-          ruby-version: .ruby-version
           bundler-cache: true
       - name: Generate binstubs
         run: bundle binstubs --force brakeman rubocop

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           bundler-cache: true
       - name: Generate binstubs
-        run: bundle binstubs brakeman rubocop
+        run: bundle binstubs --force brakeman rubocop
         # run: bundle binstubs bundler-audit brakeman rubocop
       # Add or replace any other lints here
       # - name: Security audit dependencies

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           bundler-cache: true
       - name: Generate binstubs
-        run: bundle binstubs --force brakeman rubocop
+        run: bundle binstubs brakeman rubocop
         # run: bundle binstubs bundler-audit brakeman rubocop
       # Add or replace any other lints here
       # - name: Security audit dependencies

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -53,7 +53,7 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
       - name: Generate binstubs
-        run: bundle binstubs brakeman rubocop
+        run: bundle binstubs --force brakeman rubocop
         # run: bundle binstubs bundler-audit brakeman rubocop
       # Add or replace any other lints here
       # - name: Security audit dependencies

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1 # ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
         with:
+          ruby-version: .ruby-version
           bundler-cache: true
       - name: Generate binstubs
         run: bundle binstubs brakeman rubocop


### PR DESCRIPTION
linting fails with an error "Brakeman 6.2.1 is not the latest version 6.2.2". `bundle binstubs --forc`e seems to fix this.