### PR TITLE
Fetch only new events

### DIFF
--- a/app/jobs/scrape_job.rb
+++ b/app/jobs/scrape_job.rb
@@ -22,13 +22,18 @@ class ScrapeJob < ActiveJob::Base
     Nokogiri::HTML(response.body)
   end
 
-  # From the safed index page, look for all festivals in supported countries and save the link to the details page
+  # From the saved index page, look for all festivals in supported countries and save the link to the details page
   def self.collect_links(main_page_nokogiri_doc)
     # - Find all div class="pins">Germany</div>
     listed_event = main_page_nokogiri_doc.search('.maintitles')
     listed_event.map do |event|
       country = event.search('.pins').text
-      event.attribute_nodes.first.value if Event::SUPPORTED_COUNTRIES.include?(country)
+      subpage_url = event.attribute_nodes.first.value if Event::SUPPORTED_COUNTRIES.include?(country)
+      title = event.attribute_nodes[3].value.gsub(' - Teachers Confirmed', '')
+
+      next if Event.find_by(title: title)
+
+      subpage_url
     end.compact
   end
 
@@ -71,7 +76,7 @@ class ScrapeJob < ActiveJob::Base
     begin event.save!
           'all good'
     rescue ActiveRecord::RecordInvalid
-      debugger # rubocop:disable Lint/Debugger
+      debugger unless Rails.env.production?
     end
   end
 end

--- a/app/jobs/scrape_job.rb
+++ b/app/jobs/scrape_job.rb
@@ -31,7 +31,7 @@ class ScrapeJob < ActiveJob::Base
       subpage_url = event.attribute_nodes.first.value if Event::SUPPORTED_COUNTRIES.include?(country)
       title = event.attribute_nodes[3].value.gsub(' - Teachers Confirmed', '')
 
-      next if Event.find_by(title: title)
+      next if Event.upcoming.find_by(title: title)
 
       subpage_url
     end.compact

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,7 +20,6 @@ class Event < ApplicationRecord
   scope :filter_by_country, ->(country) { where(country:) }
   scope :filter_by_dance_types, ->(dance) { where('DANCE_TYPES && array[?]', dance) }
 
-  # currently only used for command line
   def upcoming?
     end_date > Date.today
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,7 +20,7 @@ class Event < ApplicationRecord
   scope :filter_by_country, ->(country) { where(country:) }
   scope :filter_by_dance_types, ->(dance) { where('DANCE_TYPES && array[?]', dance) }
 
-  # currently only used for comand line
+  # currently only used for command line
   def upcoming?
     end_date > Date.today
   end


### PR DESCRIPTION
fetch only those events that are not in the database yet, based on the title.

However, check that the potential duplicate event is upcoming, as many events will have the same title every year.