### PR TITLE
add published and parent_event_id to events

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ This app can be deployed with the [kamal](https://kamal-deploy.org/) tool. For t
 * Add option to suggest edits of existing events
 * Make the page look nice
 * Possibly add capybara specs
-* Add hotwire / stimulus where it makes sense
-* Fetch only new events
+* Add turbo / stimulus where it makes sense
+* Upgrade to rails 8

--- a/app/commands/events/index.rb
+++ b/app/commands/events/index.rb
@@ -6,7 +6,7 @@ module Events
 
     def execute
       # see https://www.justinweiss.com/articles/search-and-filter-rails-models-without-bloating-your-controller/
-      @events = Event.upcoming.where(nil).order(:start_date) # creates an anonymous scope
+      @events = Event.published.upcoming.where(nil).order(:start_date) # creates an anonymous scope
       @events = @events.filter_by_city(city) if city.present?
       @events = @events.filter_by_country(country) if country.present?
       @events = @events.filter_by_dance_types(dance_type) if dance_type.present?

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -14,7 +14,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    @event = Event.find(params[:id])
+    @event = Event.published.find(params[:id])
   end
 
   def index
@@ -30,7 +30,7 @@ class EventsController < ApplicationController
   def event_params
     params.require(:event).permit(
       :title, :description, :dance_types, :start_date, :end_date, :website, :sign_up_start_date,
-      :event_email, :country, :city
+      :event_email, :country, :city, :parent_event_id
     )
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,6 +15,7 @@ class Event < ApplicationRecord
 
   scope :upcoming, -> { where('end_date > ?', Date.today) }
   scope :past, -> { where('end_date <= ?', Date.today) }
+  scope :published, -> { where(published: true) }
 
   scope :filter_by_city, ->(city) { where(city:) }
   scope :filter_by_country, ->(country) { where(country:) }

--- a/db/migrate/20241210113513_add_published_to_events.rb
+++ b/db/migrate/20241210113513_add_published_to_events.rb
@@ -1,0 +1,6 @@
+class AddPublishedToEvents < ActiveRecord::Migration[7.2]
+  def change
+    add_column :events, :published, :boolean, default: false,  null: false
+    add_reference :events, :parent_event_id, foreign_key: { to_table: :events }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_06_094008) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_10_113513) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_06_094008) do
     t.text "dance_types", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "published", default: false, null: false
+    t.bigint "parent_event_id_id"
+    t.index ["parent_event_id_id"], name: "index_events_on_parent_event_id_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -37,4 +40,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_06_094008) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_foreign_key "events", "events", column: "parent_event_id_id"
 end

--- a/spec/factories/events_factory.rb
+++ b/spec/factories/events_factory.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     country { 'Germany' }
     city { 'Hamburg' }
     dance_types { ['shag'] }
+    published { true }
 
     trait(:past) do
       start_date { 1.month.ago }

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe 'Events', type: :request do
         expect(response.body).to include event.start_date.strftime('%B %d, %Y')
         expect(response.body).to include event.end_date.strftime('%B %d, %Y')
       end
+
+      it 'does not show an unpublished event' do
+        event = create(:event, published: false, title: 'not published')
+        get "/events/#{event.id}"
+
+        expect(response).to have_http_status(:not_found)
+        # expect(response.body).not_to include 'not published'
+      end
     end
   end
 
@@ -66,6 +74,14 @@ RSpec.describe 'Events', type: :request do
       table = document.search('table')
       # table.text is e.g. "MarchHamburgMarch 01, 2099JanuaryHamburgJanuary 01, 2099"
       expect(table.text).to start_with 'January'
+    end
+
+    it 'does not show unpublished events' do
+      create(:event)
+      create(:event, published: false, title: 'suggested event')
+      get '/events'
+
+      expect(response.body).not_to include 'suggested event'
     end
 
     context 'filters' do


### PR DESCRIPTION
This is some preparation work to allow external people to suggest new events and edits to events. If an edit is suggested, a new, unpublished event will be created, that is linked to the original event. If a new event is suggested, it will also be unpublished first, until an admin publishes the event.